### PR TITLE
Reducers accept superset of bundle state type

### DIFF
--- a/src/bundles/asyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
+++ b/src/bundles/asyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
@@ -213,6 +213,14 @@ describe("createAsyncResourceBundle", () => {
         // @ts-expect-error
         reducer(undefined, { type: "WHAT_IS_THIS_NONSENSE" });
       });
+      it("should not accept subsets of the reducer state", () => {
+        const { data: _, ...subsetOfState } = initialState;
+        // @ts-expect-error
+        reducer(subsetOfState, actions.fetchStart());
+      });
+      it("should accept supersets of the reducer state", () => {
+        reducer({ ...initialState, extra: "things" }, actions.fetchStart());
+      });
     });
     describe("Fetch action handlers", () => {
       describe("Start action handler", () => {

--- a/src/bundles/asyncResourceBundle/index.ts
+++ b/src/bundles/asyncResourceBundle/index.ts
@@ -130,7 +130,10 @@ const createAsyncResourceBundle = <
 
   return {
     initialState,
-    reducer: (state: LocalState = initialState, action: Actions<Resource> | Action): LocalState => {
+    reducer: <TState extends LocalState>(
+      state = initialState as TState,
+      action: Actions<Resource> | Action
+    ): TState => {
       if (!isAction(action)) {
         return state;
       }


### PR DESCRIPTION
Reducers now accept a superset of the bundle state type, to enable the extension of reducers with additional state.