### PR TITLE
fix(reducer): Reducers accept superset of bundle state type

### DIFF
--- a/src/bundles/asyncResourceBundle/index.ts
+++ b/src/bundles/asyncResourceBundle/index.ts
@@ -130,10 +130,10 @@ const createAsyncResourceBundle = <
 
   return {
     initialState,
-    reducer: <TState extends LocalState>(
-      state = initialState as TState,
+    reducer: <ReducerState extends LocalState>(
+      state = initialState as ReducerState,
       action: Actions<Resource> | Action
-    ): TState => {
+    ): ReducerState => {
       if (!isAction(action)) {
         return state;
       }


### PR DESCRIPTION
Reducers now accept a superset of the bundle state type, to enable the extension of reducers with additional state.